### PR TITLE
refactor(dataset): work with nested Datasets on to_jsonobject

### DIFF
--- a/src/incendium/dataset.py
+++ b/src/incendium/dataset.py
@@ -78,6 +78,22 @@ class _NanoXML(object):
         return self._output
 
 
+def _format_object(obj):
+    # type: (Any) -> Any
+    """Format the object.
+
+    Args:
+        obj: The value to format.
+
+    Returns:
+        The representation of the object.
+    """
+    _obj = obj
+    if isinstance(obj, Dataset):
+        _obj = _to_jsonobject(obj)
+    return _obj
+
+
 def _format_value(obj, header=""):
     # type: (Any, String) -> String
     """Format the value to be properly represented in JSON.
@@ -146,6 +162,30 @@ def _to_json(dataset, root=None, is_root=True):
     return ret_str
 
 
+def _to_jsonobject(dataset):
+    # type: (Dataset) -> List[DictStringAny]
+    """Convert a Dataset into a Python list of dictionaries.
+
+    Args:
+        dataset: The input dataset.
+
+    Returns:
+        The Dataset as a Python object.
+    """
+    data = []
+    headers = dataset.getColumnNames()
+    row_count = dataset.getRowCount()
+
+    for i in range(row_count):
+        row_dict = {
+            header: _format_object(dataset.getValueAt(i, header))
+            for header in headers
+        }
+        data.append(row_dict)
+
+    return data
+
+
 def to_json(dataset, root=None):
     # type: (Dataset, Optional[String]) -> String
     """Return a string JSON representation of the Dataset.
@@ -170,17 +210,7 @@ def to_jsonobject(dataset):
     Returns:
         The Dataset as a Python object.
     """
-    data = []
-    headers = dataset.getColumnNames()
-    row_count = dataset.getRowCount()
-
-    for i in range(row_count):
-        row_dict = {
-            header: dataset.getValueAt(i, header) for header in headers
-        }
-        data.append(row_dict)
-
-    return data
+    return _to_jsonobject(dataset)
 
 
 def to_xml(dataset, root="root", element="row", indent="\t"):


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`to_jsonobject` does not properly "expand" nested Datasets.

See current output:

```text
[{u'Timezone': u'CST', u'Dataset': Dataset [2R ⅹ 2C], u'City': u'\u5317\u4eac\u5e02', u'Population': 21542000, u'GMTOffset': 8}, {u'Timezone': u'CET', u'Dataset': None, u'City': u'\u010cern\xe1 Hora', u'Population': 2100, u'GMTOffset': 1}, {u'Timezone': u'BRT', u'Dataset': None, u'City': u'Jundia\xed', u'Population': 423006, u'GMTOffset': -3}, {u'Timezone': u'EST', u'Dataset': None, u'City': u'New York', u'Population': 8336817, u'GMTOffset': -5}, {u'Timezone': u'MST', u'Dataset': None, u'City': u'Mazatl\xe1n', u'Population': 502547, u'GMTOffset': -7}]
```

Where the `Dataset` column is only showing `Dataset [2R ⅹ 2C]`.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
The current method expands nested Datasets.

```text
[{u'Timezone': u'CST', u'Dataset': [{u'id': 1, u'value': u'one'}, {u'id': 2, u'value': u'two'}], u'City': u'\u5317\u4eac\u5e02', u'Population': 21542000, u'GMTOffset': 8}]

```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
