### PR TITLE
ci: reorder build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ignition-api-stubs
-        python -m pip install pylint
-    - name: Analysing the code with mypy
-      run: |
-        mypy src
     - name: Analysing the code with pylint
       run: |
-        pylint --disable=no-name-in-module --verbose src
+        python -m pip install pylint
+        pylint src
+    - name: Analysing the code with mypy
+      run: |
+        python -m pip install ignition-api-stubs
+        mypy src


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are currently disabling pylint E0611 (no-name-in-module) which might hurt us in the future.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
By reordering the build steps we are running pylint without disabling E0611.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
installing `ignition-api-stubs` may be interfering with pylint

See pulls: #54, and #62