### PR TITLE
refactor(db): return BasicDataset on get_data and o_get_data

### DIFF
--- a/src/incendium/db.py
+++ b/src/incendium/db.py
@@ -253,7 +253,7 @@ def _execute_sp(
 
     return {
         "output_params": _out_params,
-        "result_set": call.getResultSet() if get_result_set else None,
+        "result_set": call.getResultSet() if get_result_set else BasicDataset(),
         "return_value": call.getReturnValue() if get_ret_val else None,
         "update_count": call.getUpdateCount() if get_update_count else -1,
     }
@@ -324,7 +324,7 @@ def get_data(
     database="",  # type: String
     params=None,  # type: Optional[List[InParam]]
 ):
-    # type: (...) -> Optional[BasicDataset]
+    # type: (...) -> BasicDataset
     """Get data by executing a stored procedure.
 
     Args:
@@ -337,7 +337,7 @@ def get_data(
 
     Returns:
         A Dataset that is the resulting data of the stored procedure
-        call, if any.
+        call.
     """
     result = _execute_sp(
         stored_procedure,
@@ -372,7 +372,7 @@ def get_output_params(
             objects. Optional.
 
     Returns:
-        A Python dictionary of OUTPUT paramaters.
+        A Python dictionary of OUTPUT parameters.
     """
     result = _execute_sp(
         stored_procedure,
@@ -470,7 +470,7 @@ def o_get_data(
     database="",  # type: String
     in_params=None,  # type: Optional[List[InParam]]
 ):
-    # type: (...) -> Tuple[Optional[BasicDataset], DictIntStringAny]
+    # type: (...) -> Tuple[BasicDataset, DictIntStringAny]
     """Get data by executing a stored procedure and OUTPUT parameters.
 
     Args:
@@ -485,7 +485,7 @@ def o_get_data(
 
     Returns:
         A tuple containing a Dataset that is the resulting data of the
-        stored procedure call, if any, and the OUTPUT parameters.
+        stored procedure call, and the OUTPUT parameters.
     """
     result = _execute_sp(
         stored_procedure,

--- a/src/incendium/helper/types.py
+++ b/src/incendium/helper/types.py
@@ -13,7 +13,7 @@ SProcResult = TypedDict(
     "SProcResult",
     {
         "output_params": DictIntStringAny,
-        "result_set": Optional[BasicDataset],
+        "result_set": BasicDataset,
         "return_value": Optional[int],
         "update_count": int,
     },


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`get_data` and `o_get_data` return `Optional[BasicDataset]`

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
Both now return `BasicDataset`

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Since `get_data` and `o_get_data` return `BasicDataset` instead of `Optional[BasicDataset]`, code where users checked if the value was `None` should  be updated as it is no longer needed.

## Other information
