### PR TITLE
chore: migrate flake8, isort, and pydocstyle to tox.ini

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-ignore = F401, F821
-max-complexity = 10
-max-doc-length = 72
-max-line-length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,6 @@ repos:
     rev: 6.1.1
     hooks:
       - id: pydocstyle
-        additional_dependencies:
-          - '.[toml]'
   - repo: local
     hooks:
       - id: pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,5 @@ requires = [
 [tool.commitizen]
 name = "cz_conventional_commits"
 
-[tool.isort]
-extra_standard_library = ["typing"]
-profile = "black"
-py_version = 27
-
 [tool.mypy]
 python_version = 2.7
-
-[tool.pydocstyle]
-convention = "google"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/thecesrom/incendium
 author = César Román
 author_email = cesar@thecesrom.dev
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,42 @@
 [tox]
-envlist = py27,py310-{mypy,pylint}
+envlist =
+    py310-{lint, typecheck}
+    py27
+isolated_build = true
 skip_missing_interpreters = true
 
-[gh]
-python =
-    2.7 = py27
-    3.10 = py310-mypy,py310-pylint
-
-[testenv]
-deps =
-    -rrequirements.txt
-
-[testenv:py310-mypy]
-description = mypy
-skip_install = true
-deps =
-    ignition-api-stubs
-commands =
-    mypy src
-
-[testenv:py310-pylint]
-description = pylint
+[testenv:py310-lint]
+description = run static analysis and style check using pylint
 skip_install = true
 deps =
     pylint
 commands =
     pylint src
+
+[testenv:py310-typecheck]
+description = run type check on code base using mypy
+skip_install = true
+deps =
+    -rrequirements.txt
+commands =
+    mypy src
+
+[flake8]
+ignore = F821
+max-complexity = 10
+max-doc-length = 72
+max-line-length = 88
+
+[gh]
+python =
+    2.7 = py27
+    3.10 = py310-lint,py310-typecheck
+
+[isort]
+extra_standard_library = typing
+profile = black
+py_version = 27
+
+[pydocstyle]
+add_select = D400, D401
+convention = google


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](/thecesrom/incendium/blob/code/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Project maintenance

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`flake8` uses `.flake8, while `isort` and `pydocstyle` use `pyproject.toml` for their settings.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
Configure all three using `tox.ini`. Removing `.flake8` and stop using `pydocstyle[toml]` as `toml` appears to be unmaintained.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
