### PR TITLE
build(deps): freeze flake8 at 5.0.4

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@
 
 Please check if your PR fulfills the following requirements:
 
-- [ ] The commit message follows our [commit message format](/thecesrom/incendium/blob/code/CONTRIBUTING.md#commit-message-format).
+- [ ] The commit message follows our [commit message format](/thecesrom/incendium/blob/code/CONTRIBUTING.md#commit-message-format)
+- [ ] All `tox` tests have succeeded
 
 ## PR Type
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,17 @@ on:
 
 jobs:
   test:
-    name: test ${{ matrix.python-version }}
+    name: ${{ matrix.tox-env }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["2.7", "3.10"]
+        include:
+          - python-version: '2.7'
+            tox-env: install
+          - python-version: '3.10'
+            tox-env: lint
+          - python-version: '3.10'
+            tox-env: typecheck
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -22,13 +28,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
-
-    - name: Setup test suite
-      run: |
-        tox --notest
+        python -m pip install --upgrade pip tox
 
     - name: Run tests
       run: |
-        tox
+        tox -e ${{ matrix.tox-env }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,3 @@
-ci:
-  autoupdate_commit_msg: 'build(deps): pre-commit autoupdate'
-  skip: [pylint]
-
 repos:
   - repo: https://github.com/aio-libs/sort-all
     rev: v1.2.0
@@ -16,7 +12,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/pydocstyle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,39 @@ Please join us on or [Discussions](https://github.com/incendium/discussions/disc
 
 If you find a bug or if something is missing in the source code, you can help us by submitting an issue, or even better, you can [submit a Pull Request](#pull-requests) with a fix.
 
+## Getting ready to contribute
+
+For **incendium** we rely on Python 2.7.18 for development, and Python 3.10 to run tests and style checks with `pre-commit` and `tox`.
+
+### Setting up your local environment
+
+1. Install Python 2.7.18 and the latest 3.10 release
+1. Install the required packages for development you may run the following command:
+
+    ```sh
+    python2 -m pip install --requirement requirements.txt
+    ```
+
+1. Install Python 3 tools
+
+    1. [`pre-commit`](https://pre-commit.com/)
+
+        ```sh
+        python3 -m pip install pre-commit
+        ```
+
+        1. Install the git hook scripts
+
+            ```sh
+            pre-commit install
+            ```
+
+    1. [`tox`](https://tox.wiki/)
+
+        ```sh
+        python3 -m pip install tox
+        ```
+
 ## Pull Requests
 
 We use the [GitHub flow](https://guides.github.com/introduction/flow/) as main versioning workflow.

--- a/tox.ini
+++ b/tox.ini
@@ -4,23 +4,23 @@ envlist =
     lint
     typecheck
 isolated_build = true
-skip_missing_interpreters = true
 
 [testenv:install]
 description = install package
 basepython = python2.7
 
 [testenv:lint]
-description = run static analysis and style check using pylint
+description = run static analysis and style check
 basepython = python3.10
 skip_install = true
 deps =
+    pre-commit
     pylint
 commands =
-    pylint src
+    pre-commit run --all-files --show-diff-on-failure
 
 [testenv:typecheck]
-description = run type check on code base using mypy
+description = run type check on code base
 basepython = python3.10
 skip_install = true
 deps =
@@ -29,7 +29,7 @@ commands =
     mypy --config-file tox.ini src
 
 [flake8]
-ignore = F401, F821
+ignore = F821
 max-complexity = 10
 max-doc-length = 72
 max-line-length = 88


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](/thecesrom/incendium/blob/code/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`pre-commit.ci` updated `flake8` to version 6.0.0 in bc77f15 which depends on `puflakes` 3.0.0 which removes handling of python 2.x `# type:` comments.

This made us ignore error code `F401`, which may lower the quality of our code in the long term.

Issue Number: #132

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will use `tox` to run our pre-commit hooks and disable `pre-commit.ci`, freeze `flake8` at version 5.0.4 and remove `F401` from the ignored list.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
