### PR TITLE
revert(ci): use Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: ci
 
 on:
-  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -16,9 +15,9 @@ jobs:
         include:
           - python-version: '2.7'
             tox-env: install
-          - python-version: '3.11'
+          - python-version: '3.10'
             tox-env: lint
-          - python-version: '3.11'
+          - python-version: '3.10'
             tox-env: typecheck
     steps:
     - uses: actions/checkout@v3

--- a/.pylintrc
+++ b/.pylintrc
@@ -53,7 +53,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.11
+py-version=3.10
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -19,7 +19,7 @@ rule_settings:
   - refactoring
   - suggestion
   - comment
-  python_version: '3.11'
+  python_version: '3.10'
 
 metrics:
   quality_threshold: 25.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,11 @@ If you find a bug or if something is missing in the source code, you can help us
 
 ## Getting ready to contribute
 
-For **incendium** we rely on Python 2.7.18 for development, and Python 3.11 to run tests and style checks with `pre-commit` and `tox`.
+For **incendium** we rely on Python 2.7.18 for development, and Python 3.10 to run tests and style checks with `pre-commit` and `tox`.
 
 ### Setting up your local environment
 
-1. Install Python 2.7.18 and the latest 3.11 release
+1. Install Python 2.7.18 and the latest 3.10 release
 1. Install the required packages for development you may run the following command:
 
     ```sh

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ basepython = python2.7
 
 [testenv:lint]
 description = run static analysis and style check
-basepython = python3.11
+basepython = python3.10
 skip_install = true
 deps =
     pre-commit
@@ -21,7 +21,7 @@ commands =
 
 [testenv:typecheck]
 description = run type check on code base
-basepython = python3.11
+basepython = python3.10
 skip_install = true
 deps =
     ignition-api-stubs


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](/thecesrom/incendium/blob/code/CONTRIBUTING.md#commit-message-format)
- [x] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Revert

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are using Python 3.11 for tox/CI.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will revert back to Python 3.10, as `typed-ast` is not supported in 3.11.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Refs: d33d875