### PR TITLE
ci: use default cache location for pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
   test:
     name: tox
     runs-on: ubuntu-20.04
-    env:
-      PRE_COMMIT_HOME: ${{ github.workspace }}/.cache/pre-commit-cache
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -42,7 +40,7 @@ jobs:
       - name: Cache pre-commit
         uses: actions/cache@v3
         with:
-          path: ${{ env.PRE_COMMIT_HOME }}
+          path: ~/.cache/pre-commit
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pre-commit-

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,6 @@ basepython = python2.7
 
 [testenv:lint]
 description = run static analysis and style check
-passenv =
-    PRE_COMMIT_HOME
 basepython = {[base]basepython}
 skip_install = true
 deps =


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](/thecesrom/incendium/blob/code/CONTRIBUTING.md#commit-message-format)
- [x] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are using `${{ github.workspace }}/.cache/pre-commit-cache` for caching `pre-commit` and passing that in an environment variable to `tox`'s `lint` env.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will use `pre-commit`'s default cache location.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
