### PR TITLE
build: move mypy configuration to mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+enable_error_code = ignore-without-code
+mypy_path = $MYPY_CONFIG_FILE_DIR/src
+python_version = 2.7
+strict = true
+warn_return_any = true

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ skip_install = true
 deps =
     {[base]deps}
 commands =
-    mypy --config-file tox.ini src
+    mypy src
 
 [testenv:stubgen]
 description = generate stubs
@@ -51,13 +51,6 @@ max-line-length = 88
 extra_standard_library = typing
 profile = black
 py_version = 27
-
-[mypy]
-enable_error_code = ignore-without-code
-mypy_path = src
-python_version = 2.7
-strict = true
-warn_return_any = true
 
 [pydocstyle]
 add_select = D400, D401


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](/thecesrom/incendium/blob/code/CONTRIBUTING.md#commit-message-format)
- [x] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`mypy`'s configuration is found at `tox.ini`.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will simplify running `mypy` against our codebase by using its default location; `mypy.ini`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
